### PR TITLE
HUB-909: Pull from maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,30 +1,21 @@
+plugins {
+    id 'com.github.johnrengelman.shadow' version '5.2.0'
+}
+
+apply plugin: 'java'
+
 group 'uk.gov.verify'
 version '1.0-SNAPSHOT'
 
-
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:5.0.0'
-    }
-}
-
-apply plugin: 'com.github.johnrengelman.shadow'
-apply plugin: 'java'
-
 def dependencyVersions = [
         dropwizard:"1.3.5",
-        event_emmiter: "0.0.1-58"
+        event_emmiter: "2.0.0-83"
 ]
 
 repositories {
     if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
         logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-        maven { url 'https://dl.bintray.com/alphagov/maven' } // For dropwizard-logstash
-        maven { url 'https://dl.bintray.com/alphagov/maven-test' } // For other public verify binaries
-        jcenter()
+        mavenCentral()
     }
     else {
         maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }
@@ -49,6 +40,7 @@ dependencies {
             'com.hubspot.dropwizard:dropwizard-guicier:1.0.0.6',
             'org.bouncycastle:bcprov-ext-jdk15on:1.58',
             'com.amazonaws:aws-encryption-sdk-java:1.3.1',
+            'com.amazonaws:aws-java-sdk-kms:1.11.277',
             'uk.gov.ida:verify-event-emitter:' + dependencyVersions.event_emmiter,
             'javax.xml.bind:jaxb-api:2.3.1',
             'com.sun.xml.bind:jaxb-core:2.3.0.1',

--- a/src/main/java/uk/gov/verify/eventsystem/loader/configuration/EventEmitterConfiguration.java
+++ b/src/main/java/uk/gov/verify/eventsystem/loader/configuration/EventEmitterConfiguration.java
@@ -33,6 +33,10 @@ public class EventEmitterConfiguration implements Configuration {
 
     @Valid
     @JsonProperty
+    private String sourceQueueName;
+
+    @Valid
+    @JsonProperty
     private URI apiGatewayUrl;
 
 
@@ -66,6 +70,9 @@ public class EventEmitterConfiguration implements Configuration {
         if (decryptor == null) return Base64.getDecoder().decode(encryptionKey);
         return decryptor.decryptEncryptionKey(encryptionKey);
     }
+
+    @Override
+    public String getSourceQueueName() { return sourceQueueName; }
 
     @Override
     public URI getApiGatewayUrl() { return apiGatewayUrl; }

--- a/src/test/resources/test-data.json
+++ b/src/test/resources/test-data.json
@@ -12,7 +12,7 @@
       "session_expiry_time": "2019-01-01T12:00:00.000Z",
       "transaction_entity_id": "https://idp-entity-id",
       "minimum_level_of_assurance": "LEVEL_2",
-      "required_level_of_assurance": "LEVEL_2",
+      "preferred_level_of_assurance": "LEVEL_2",
       "principal_ip_address_as_seen_by_hub": "111.222.222.111 10.0.0.1"
     }
   },
@@ -29,7 +29,7 @@
       "session_expiry_time": "2019-01-01T12:00:00.000Z",
       "transaction_entity_id": "https://idp-entity-id",
       "minimum_level_of_assurance": "LEVEL_2",
-      "required_level_of_assurance": "LEVEL_2",
+      "preferred_level_of_assurance": "LEVEL_2",
       "principal_ip_address_as_seen_by_hub": "111.222.222.111 10.0.0.1"
     }
   }


### PR DESCRIPTION
This updates the build.gradle to pull from maven central for public
builds. This has required a few changes:

Update the shadow plugin to pull from the gradle plugin portal.

Add the AWS KMS sdk. This was previously brought in through the
verify-event-emitter dependency. The latest version doesn't bring it
in.

Update the `EventEmitterConfiguration` to include a new field defined
on the abstract `Configuration` class from `verify-event-emitter`.

Update the `required_level_of_assurance` key in the test data to
`preferred_level_of_assurance`. The enum of allowed keys can be found in
`uk.gov.ida.eventemitter.EventDetailsKey`